### PR TITLE
Feature/measurement parameteres

### DIFF
--- a/ProcessSmarterTestPackage/Processors/Common/ItemPool/TestItem/ItemScoreParameterProcessor.cs
+++ b/ProcessSmarterTestPackage/Processors/Common/ItemPool/TestItem/ItemScoreParameterProcessor.cs
@@ -2,7 +2,6 @@
 using SmarterTestPackage.Common.Data;
 using ValidateSmarterTestPackage;
 using ValidateSmarterTestPackage.RestrictedValues.Enums;
-using ValidateSmarterTestPackage.RestrictedValues.RestrictedList;
 using ValidateSmarterTestPackage.Validators;
 using ValidateSmarterTestPackage.Validators.Convenience;
 
@@ -18,12 +17,12 @@ namespace ProcessSmarterTestPackage.Processors.Common.ItemPool.TestItem
                 {
                     "measurementparameter", StringValidator.IsValidNonEmptyWithLength(50)
                         .AddAndReturn(new RequiredEnumValidator(ErrorSeverity.Degraded,
-                            RestrictedList.RestrictedLists[RestrictedListItems.MeasurementParameter]))
+                            RestrictedListItems.MeasurementParameter))
                 },
                 {
                     "value", new ValidatorCollection
                     {
-                        new RequiredDecimalValidator(ErrorSeverity.Degraded),
+                        new RequiredDoubleValidator(ErrorSeverity.Degraded),
                         new MaxLengthValidator(ErrorSeverity.Degraded, 30)
                     }
                 }

--- a/ProcessSmarterTestPackage/Processors/Common/ItemPool/TestItem/ItemScoredDimensionProcessor.cs
+++ b/ProcessSmarterTestPackage/Processors/Common/ItemPool/TestItem/ItemScoredDimensionProcessor.cs
@@ -3,7 +3,6 @@ using SmarterTestPackage.Common.Data;
 using SmarterTestPackage.Common.Extensions;
 using ValidateSmarterTestPackage;
 using ValidateSmarterTestPackage.RestrictedValues.Enums;
-using ValidateSmarterTestPackage.RestrictedValues.RestrictedList;
 using ValidateSmarterTestPackage.Validators;
 using ValidateSmarterTestPackage.Validators.Convenience;
 
@@ -19,16 +18,20 @@ namespace ProcessSmarterTestPackage.Processors.Common.ItemPool.TestItem
                 {
                     "measurementmodel", StringValidator.IsValidNonEmptyWithLength(100)
                         .AddAndReturn(new RequiredEnumValidator(ErrorSeverity.Degraded,
-                            RestrictedList.RestrictedLists[RestrictedListItems.MeasurementModel]))
+                            RestrictedListItems.MeasurementModel))
                 },
                 {
                     "scorepoints", IntValidator.IsValidPositiveNonEmptyWithLength(10)
                 },
                 {
-                    "weight", DecimalValidator.IsValidPositiveNonEmptyWithLength(30)
+                    "weight", new ValidatorCollection
+                    {
+                        new RequiredDoubleValidator(ErrorSeverity.Degraded),
+                        new MaxLengthValidator(ErrorSeverity.Degraded, 30)
+                    }
                 },
                 {
-                    "dimension", StringValidator.IsValidOptionalNonEmptyWithLength(200)
+                    "dimension", new NoValidator(ErrorSeverity.Degraded) // Removed validation for optional field
                 }
             };
             Navigator.GenerateList("itemscoreparameter")

--- a/ProcessSmarterTestPackage/Processors/Common/ItemPool/TestItem/TestItemProcessor.cs
+++ b/ProcessSmarterTestPackage/Processors/Common/ItemPool/TestItem/TestItemProcessor.cs
@@ -48,7 +48,7 @@ namespace ProcessSmarterTestPackage.Processors.Common.ItemPool.TestItem
                 .ForEach(x => Processors.Add(new PoolPropertyProcessor(x, packageType)));
             RemoveAttributeValidation("poolproperty", "itemcount");
 
-            Navigator.GenerateList("itemscoreddimension")
+            Navigator.GenerateList("itemscoredimension")
                 .ForEach(x => Processors.Add(new ItemScoredDimensionProcessor(x, packageType)));
         }
 

--- a/SmarterTestPackage.Common/Data/OptionalStringOrErrorList.cs
+++ b/SmarterTestPackage.Common/Data/OptionalStringOrErrorList.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace SmarterTestPackage.Common.Data
+{
+    public class OptionalStringOrErrorList
+    {
+        public OptionalStringOrErrorList()
+        {
+            Errors = new List<string>();
+        }
+
+        public string Value { get; set; }
+        public IList<string> Errors { get; set; }
+    }
+}

--- a/SmarterTestPackage.Common/SmarterTestPackage.Common.csproj
+++ b/SmarterTestPackage.Common/SmarterTestPackage.Common.csproj
@@ -38,6 +38,7 @@
     <Compile Include="ContentPackage\ContentPackage.cs" />
     <Compile Include="Data\CrossPackageValidationError.cs" />
     <Compile Include="Data\GroupItemInfo.cs" />
+    <Compile Include="Data\OptionalStringOrErrorList.cs" />
     <Compile Include="Data\PerformanceLevel.cs" />
     <Compile Include="Data\ErrorSeverity.cs" />
     <Compile Include="Data\PackageType.cs" />

--- a/TabulateSmarterTestPackage/TabulateSmarterTestPackage.csproj
+++ b/TabulateSmarterTestPackage/TabulateSmarterTestPackage.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tabulators\TestPackageTabulator.cs" />
     <Compile Include="Utilities\FormatHelper.cs" />
+    <Compile Include="Utilities\MathHelper.cs" />
     <Compile Include="Utilities\ReportingUtility.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
+++ b/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
@@ -47,11 +47,11 @@ namespace TabulateSmarterTestPackage.Tabulators
 
         private static readonly XPathExpression sXp_Parameter2 =
             XPathExpression.Compile(
-                "itemscoredimension/itemscoreparameter[@measurementparameter='a' or @measurementparameter='b0']/@value");
+                "itemscoredimension/itemscoreparameter[@measurementparameter='b' or @measurementparameter='b0']/@value");
 
         private static readonly XPathExpression sXp_Parameter3 =
             XPathExpression.Compile(
-                "itemscoredimension/itemscoreparameter[@measurementparameter='a' or @measurementparameter='b1']/@value");
+                "itemscoredimension/itemscoreparameter[@measurementparameter='c' or @measurementparameter='b1']/@value");
 
         private static readonly XPathExpression sXp_Parameter4 =
             XPathExpression.Compile("itemscoredimension/itemscoreparameter[@measurementparameter='b2']/@value");

--- a/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
+++ b/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
@@ -159,7 +159,7 @@ namespace TabulateSmarterTestPackage.Tabulators
                     testItem.ChildNodeWithName("identifier").ValueForAttribute("version");
                 itemFields[(int) ItemFieldNames.ItemType] = testItem.ValueForAttribute("itemtype");
                 itemFields[(int) ItemFieldNames.PassageRef] =
-                    FormatHelper.Strip200(testItem.ChildNodeWithName("passageref").ValueForAttribute("passageref"));
+                    FormatHelper.Strip200(testItem.ChildNodeWithName("passageref")?.ValueForAttribute("passageref"));
 
                 // Process PoolProperties
                 var glossary = new List<string>();
@@ -210,49 +210,45 @@ namespace TabulateSmarterTestPackage.Tabulators
                         }
                         itemFields[fieldIndex] = ppValue;
                     }
-                    else
-                    {
-                        ReportingUtility.ReportError(testInformation[ItemFieldNames.AssessmentId],
-                            testSpecificationProcessor.PackageType,
-                            $"testspecification/{testSpecificationProcessor.PackageType.ToString().ToLower()}/itempool/testitem/poolproperty"
-                            , ErrorSeverity.Degraded,
-                            itemId, poolProperty.Navigator.OuterXml, "'{0}={1}' Unrecognized Pool Property", ppProperty,
-                            ppValue);
-                    }
                 }
                 glossary.Sort();
                 itemFields[(int) ItemFieldNames.Glossary] = string.Join(";", glossary);
 
                 var itemScoreDimension = testItem.ChildNodeWithName("itemscoredimension");
-
-                itemFields[(int) ItemFieldNames.MeasurementModel] =
-                    itemScoreDimension.ValueForAttribute("measurementmodel");
-                itemFields[(int) ItemFieldNames.Weight] =
-                    FormatHelper.FormatDouble(itemScoreDimension.ValueForAttribute("weight"));
-                itemFields[(int) ItemFieldNames.ScorePoints] = itemScoreDimension.ValueForAttribute("scorepoints");
-                itemFields[(int) ItemFieldNames.a] = FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter1));
-                itemFields[(int) ItemFieldNames.b0_b] =
-                    FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter2));
-                itemFields[(int) ItemFieldNames.b1_c] =
-                    FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter3));
-                itemFields[(int) ItemFieldNames.b2] = FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter4));
-                itemFields[(int) ItemFieldNames.b3] = FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter5));
-                var avg_b = MathHelper.CalculateAverageB(itemFields[(int) ItemFieldNames.MeasurementModel],
-                    itemFields[(int) ItemFieldNames.a], itemFields[(int) ItemFieldNames.b0_b],
-                    itemFields[(int) ItemFieldNames.b1_c], itemFields[(int) ItemFieldNames.b2],
-                    itemFields[(int) ItemFieldNames.b3], itemFields[(int) ItemFieldNames.ScorePoints]);
-                if (!avg_b.Errors.Any())
+                if (itemScoreDimension != null)
                 {
-                    itemFields[(int) ItemFieldNames.avg_b] = avg_b.Value;
-                }
-                else
-                {
-                    avg_b.Errors.ToList().ForEach(x =>
-                        ReportingUtility.ReportError(testInformation[ItemFieldNames.AssessmentId],
-                            testSpecificationProcessor.PackageType,
-                            $"testspecification/{testSpecificationProcessor.PackageType.ToString().ToLower()}/itempool/testitem/itemscoredimension",
-                            ErrorSeverity.Degraded, itemId, itemScoreDimension.Navigator.OuterXml, x)
-                    );
+                    itemFields[(int) ItemFieldNames.MeasurementModel] =
+                        itemScoreDimension.ValueForAttribute("measurementmodel");
+                    itemFields[(int) ItemFieldNames.Weight] =
+                        FormatHelper.FormatDouble(itemScoreDimension.ValueForAttribute("weight"));
+                    itemFields[(int) ItemFieldNames.ScorePoints] = itemScoreDimension.ValueForAttribute("scorepoints");
+                    itemFields[(int) ItemFieldNames.a] =
+                        FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter1));
+                    itemFields[(int) ItemFieldNames.b0_b] =
+                        FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter2));
+                    itemFields[(int) ItemFieldNames.b1_c] =
+                        FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter3));
+                    itemFields[(int) ItemFieldNames.b2] =
+                        FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter4));
+                    itemFields[(int) ItemFieldNames.b3] =
+                        FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter5));
+                    var avg_b = MathHelper.CalculateAverageB(itemFields[(int) ItemFieldNames.MeasurementModel],
+                        itemFields[(int) ItemFieldNames.a], itemFields[(int) ItemFieldNames.b0_b],
+                        itemFields[(int) ItemFieldNames.b1_c], itemFields[(int) ItemFieldNames.b2],
+                        itemFields[(int) ItemFieldNames.b3], itemFields[(int) ItemFieldNames.ScorePoints]);
+                    if (!avg_b.Errors.Any())
+                    {
+                        itemFields[(int) ItemFieldNames.avg_b] = avg_b.Value;
+                    }
+                    else
+                    {
+                        avg_b.Errors.ToList().ForEach(x =>
+                            ReportingUtility.ReportError(testInformation[ItemFieldNames.AssessmentId],
+                                testSpecificationProcessor.PackageType,
+                                $"testspecification/{testSpecificationProcessor.PackageType.ToString().ToLower()}/itempool/testitem/itemscoredimension",
+                                ErrorSeverity.Degraded, itemId, itemScoreDimension.Navigator.OuterXml, x)
+                        );
+                    }
                 }
 
                 // bprefs

--- a/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
+++ b/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
@@ -237,6 +237,23 @@ namespace TabulateSmarterTestPackage.Tabulators
                     FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter3));
                 itemFields[(int) ItemFieldNames.b2] = FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter4));
                 itemFields[(int) ItemFieldNames.b3] = FormatHelper.FormatDouble(testItem.Navigator.Eval(sXp_Parameter5));
+                var avg_b = MathHelper.CalculateAverageB(itemFields[(int) ItemFieldNames.MeasurementModel],
+                    itemFields[(int) ItemFieldNames.a], itemFields[(int) ItemFieldNames.b0_b],
+                    itemFields[(int) ItemFieldNames.b1_c], itemFields[(int) ItemFieldNames.b2],
+                    itemFields[(int) ItemFieldNames.b3], itemFields[(int) ItemFieldNames.ScorePoints]);
+                if (!avg_b.Errors.Any())
+                {
+                    itemFields[(int) ItemFieldNames.avg_b] = avg_b.Value;
+                }
+                else
+                {
+                    avg_b.Errors.ToList().ForEach(x =>
+                        ReportingUtility.ReportError(testInformation[ItemFieldNames.AssessmentId],
+                            testSpecificationProcessor.PackageType,
+                            $"testspecification/{testSpecificationProcessor.PackageType.ToString().ToLower()}/itempool/testitem/itemscoredimension",
+                            ErrorSeverity.Degraded, itemId, itemScoreDimension.Navigator.OuterXml, x)
+                    );
+                }
 
                 // bprefs
                 var bpRefProcessors = testItem.ChildNodesWithName("bpref").ToList();

--- a/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
+++ b/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
@@ -179,7 +179,10 @@ namespace TabulateSmarterTestPackage.Tabulators
                 itemFields[(int) ItemFieldNames.AssessmentGrade] = testInformation[ItemFieldNames.AssessmentGrade];
                 itemFields[(int) ItemFieldNames.AssessmentType] = testInformation[ItemFieldNames.AssessmentType];
                 itemFields[(int) ItemFieldNames.AssessmentSubtype] = testInformation[ItemFieldNames.AssessmentSubtype];
-                itemFields[(int) ItemFieldNames.AcademicYear] = testInformation[ItemFieldNames.AcademicYear];
+                itemFields[(int) ItemFieldNames.AcademicYear] =
+                    !string.IsNullOrEmpty(testInformation[ItemFieldNames.AcademicYear])
+                        ? testInformation[ItemFieldNames.AcademicYear].Split('-').FirstOrDefault()
+                        : string.Empty;
 
                 var itemId = FormatHelper.Strip200(node.Eval(sXp_ItemId));
                 itemFields[(int) ItemFieldNames.ItemId] = itemId.Split('-').Last();

--- a/TabulateSmarterTestPackage/Utilities/FormatHelper.cs
+++ b/TabulateSmarterTestPackage/Utilities/FormatHelper.cs
@@ -7,6 +7,10 @@ namespace TabulateSmarterTestPackage.Utilities
     {
         public static string Strip200(string val)
         {
+            if (string.IsNullOrEmpty(val))
+            {
+                return string.Empty;
+            }
             return val.StartsWith("200-", StringComparison.Ordinal) ? val.Substring(4) : val;
         }
 

--- a/TabulateSmarterTestPackage/Utilities/MathHelper.cs
+++ b/TabulateSmarterTestPackage/Utilities/MathHelper.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using SmarterTestPackage.Common.Data;
+
+namespace TabulateSmarterTestPackage.Utilities
+{
+    public static class MathHelper
+    {
+        public static OptionalStringOrErrorList CalculateAverageB(string measurementModel, string a, string b0,
+            string b1, string b2, string b3,
+            string scorePoints)
+        {
+            var result = new OptionalStringOrErrorList();
+
+            int scorePointsInt;
+            if (!int.TryParse(scorePoints, out scorePointsInt) || scorePointsInt == 0)
+            {
+                result.Errors.Add("[scorepoints parameter of itemscoredimension is invalid. Cannot calcualte avg_b]");
+                return result;
+            }
+
+            if (measurementModel.Equals("IRT3PLn") && scorePointsInt > 1)
+            {
+                result.Errors.Add(
+                    $"[scorepoints parameter of itemscoredimension {scorePointsInt} > # of b arguments for model IRT3PLn. Cannot calcualte avg_b]");
+            }
+
+            var bStrings = new List<string>();
+            var bDoubles = new List<double>();
+            if (!string.IsNullOrEmpty(b0))
+            {
+                double b0Double;
+                if (!double.TryParse(b0, out b0Double))
+                {
+                    result.Errors.Add($"[b0 value {b0} is present, but invalid. Cannot calcualte avg_b]");
+                }
+                else
+                {
+                    bDoubles.Add(b0Double);
+                }
+                bStrings.Add(b0);
+                if (!string.IsNullOrEmpty(b1))
+                {
+                    double b1Double;
+                    if (!double.TryParse(b1, out b1Double) && scorePointsInt > 1)
+                    {
+                        result.Errors.Add($"[b1 value {b1} is present, but invalid. Cannot calcualte avg_b]");
+                    }
+                    else
+                    {
+                        bDoubles.Add(b1Double);
+                    }
+                    bStrings.Add(b1);
+                    if (!string.IsNullOrEmpty(b2))
+                    {
+                        double b2Double;
+                        if (!double.TryParse(b2, out b2Double) && scorePointsInt > 2)
+                        {
+                            result.Errors.Add($"[b2 value {b2} is present, but invalid. Cannot calcualte avg_b]");
+                        }
+                        else
+                        {
+                            bDoubles.Add(b2Double);
+                        }
+                        bStrings.Add(b2);
+                        if (!string.IsNullOrEmpty(b3))
+                        {
+                            double b3Double;
+                            if (!double.TryParse(b3, out b3Double) && scorePointsInt > 3)
+                            {
+                                result.Errors.Add($"[b3 value {b3} is present, but invalid. Cannot calcualte avg_b]");
+                            }
+                            else
+                            {
+                                bDoubles.Add(b3Double);
+                            }
+                            bStrings.Add(b3);
+                        }
+                    }
+                }
+                else
+                {
+                    result.Errors.Add("[There are no valid b values. Cannot calcualte avg_b]");
+                }
+            }
+
+            if (a.Equals("1.000000000000000e+000") && bStrings.All(b => b.Equals("1.000000000000000e-015")))
+            {
+                result.Errors.Add("[Uncalibrated item detected. Not calculating avg_b]");
+            }
+
+            if (scorePointsInt > bDoubles.Count)
+            {
+                result.Errors.Add(
+                    $"[scorepoints parameter of itemscoredimension {scorePointsInt} > # of b arguments. Cannot calcualte avg_b]");
+            }
+
+            if (!result.Errors.Any())
+            {
+                result.Value = FormatHelper.FormatDouble(
+                    (bDoubles.Take(scorePointsInt).Sum() / scorePointsInt)
+                    .ToString(CultureInfo.InvariantCulture));
+            }
+            return result;
+        }
+    }
+}

--- a/TabulateSmarterTestPackage/Utilities/MathHelper.cs
+++ b/TabulateSmarterTestPackage/Utilities/MathHelper.cs
@@ -85,7 +85,7 @@ namespace TabulateSmarterTestPackage.Utilities
                 }
             }
 
-            if (a.Equals("1.000000000000000e+000") && bStrings.All(b => b.Equals("1.000000000000000e-015")))
+            if (a.Equals("1") && bStrings.All(b => b.Equals("1E-15")))
             {
                 result.Errors.Add("[Uncalibrated item detected. Not calculating avg_b]");
             }

--- a/ValidateSmarterTestPackage/RestrictedValues/Enums/ItemFieldNames.cs
+++ b/ValidateSmarterTestPackage/RestrictedValues/Enums/ItemFieldNames.cs
@@ -21,7 +21,6 @@
         Claim,
         Target,
         PassageRef,
-        PassageLength,
         HearingImpaired,
         ASL,
         Braille,

--- a/ValidateSmarterTestPackage/RestrictedValues/Enums/ItemFieldNames.cs
+++ b/ValidateSmarterTestPackage/RestrictedValues/Enums/ItemFieldNames.cs
@@ -46,6 +46,7 @@
         b1_c,
         b2,
         b3,
+        avg_b,
         bpref1,
         bpref2,
         bpref3,


### PR DESCRIPTION
- Alex Dean's MeasurementParameter fix
- Only returning first year listed as academic year to accommodate RDW team

ItemTabulator
- Refactored to remove passage length and direct navigation access to specific nodes in item tabulator
- Removed a couple of redundant error reports 
- Combined some logic in if statements

- Calculated avg_b for the RDW team

- Added missing path for itemscoredimension and itemscoreparameters
- Adjusted itemscoredimeension and itemscoreparameter to apply appropriate validations
- Removed error for unrecognized pool properties - extra properties should be ignored
- Added null guard to FormatHelper
- Adjusted MathHelper "default values" condition to reflect outputs of previous double formatting calls
