### PR TITLE
This appears to be a bug where the tabulator was skipping even numbered

### DIFF
--- a/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
+++ b/TabulateSmarterTestPackage/Tabulators/ItemTabulator.cs
@@ -354,7 +354,7 @@ namespace TabulateSmarterTestPackage.Tabulators
                     var bpRef = bpRefProcessors[i].ValueForAttribute("bpref");
                     if (i < MaxBpRefs)
                     {
-                        itemFields[(int) ItemFieldNames.bpref1 + i++] = bpRef;
+                        itemFields[(int) ItemFieldNames.bpref1 + i] = bpRef;
                     }
 
                     // Attempt to parse the bpref as an SBAC standard


### PR DESCRIPTION
This appears to be a bug where the tabulator was only outputting every other (odd numbered) bprefs (BlueprintReferences) due to an i++ sneaking in there where it should just be an i.